### PR TITLE
Get import/export drush commands working.

### DIFF
--- a/content_sync.services.yml
+++ b/content_sync.services.yml
@@ -46,17 +46,36 @@ services:
       arguments: ['@serializer', '@entity_type.manager','@content_sync.exporter', '@content_sync.importer']
   content_sync.normalizer.content_entity:
     class: Drupal\content_sync\Normalizer\ContentEntityNormalizer
-    arguments: ['@entity.manager', '@plugin.manager.sync_normalizer_decorator']
+    arguments:
+      - '@entity_type.manager'
+      - '@plugin.manager.sync_normalizer_decorator'
+      - '@entity_type.repository'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+      - '@entity.repository'
     tags:
       - { name: normalizer, priority: 6 }
   content_sync.normalizer.file_entity:
     class: Drupal\content_sync\Normalizer\FileEntityNormalizer
-    arguments: ['@entity.manager', '@plugin.manager.sync_normalizer_decorator', '@file_system']
+    arguments:
+      - '@entity_type.manager'
+      - '@plugin.manager.sync_normalizer_decorator'
+      - '@file_system'
+      - '@entity_type.repository'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+      - '@entity.repository'
     tags:
       - { name: normalizer, priority: 7 }
   content_sync.normalizer.user_entity:
     class: Drupal\content_sync\Normalizer\UserEntityNormalizer
-    arguments: ['@entity.manager', '@plugin.manager.sync_normalizer_decorator']
+    arguments:
+      - '@entity_type.manager'
+      - '@plugin.manager.sync_normalizer_decorator'
+      - '@entity_type.repository'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+      - '@entity.repository'
     tags:
       - { name: normalizer, priority: 7 }
   content_sync.normalizer.text_item:

--- a/src/Commands/ContentSyncCommands.php
+++ b/src/Commands/ContentSyncCommands.php
@@ -232,7 +232,7 @@ class ContentSyncCommands extends DrushCommands {
     'skiplist' => FALSE ]) {
 
     // Determine source directory.
-    $source_storage_dir = Path::canonicalize(\content_sync_get_content_directory($label));
+    $source_storage_dir = content_sync_get_content_directory($label);
     // Prepare content storage for the import.
     if ($label == ContentSyncManagerInterface::DEFAULT_DIRECTORY) {
       $source_storage = $this->getContentStorageSync();

--- a/src/Commands/ContentSyncCommands.php
+++ b/src/Commands/ContentSyncCommands.php
@@ -192,7 +192,13 @@ class ContentSyncCommands extends DrushCommands {
   }
 
   /**
-    * @hook interact @interact-content-label
+   * Select a content directory to work with.
+   *
+   * If there are multiple content directories, we need to get the the 'label'
+   * that matches the key in $content_directories from settings.php. That
+   * determines which directory we are either importing from, or exporting to.
+   *
+   * @hook interact @interact-content-label
    */
   public function interactContentLabel(InputInterface $input, ConsoleOutputInterface $output) {
     global $content_directories;

--- a/src/Content/ContentFileStorageFactory.php
+++ b/src/Content/ContentFileStorageFactory.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\content_sync\Content;
 
+use Drupal\content_sync\ContentSyncManagerInterface;
+
+
 /**
  * Provides a factory for creating content file storage objects.
  */
@@ -29,6 +32,6 @@ class ContentFileStorageFactory {
   public static function getSync() {
     // Load the class from a different namespace.
     $class = "Drupal\\Core\\Config\\FileStorage";
-    return new $class(content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/entities");
+    return new $class(content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY)."/entities");
   }
 }

--- a/src/ContentSyncManagerInterface.php
+++ b/src/ContentSyncManagerInterface.php
@@ -10,6 +10,8 @@ namespace Drupal\content_sync;
  */
 interface ContentSyncManagerInterface {
 
+  const DEFAULT_DIRECTORY = 'sync';
+
   /**
    * @return \Drupal\content_sync\Importer\ContentImporterInterface
    */

--- a/src/DependencyResolver/ImportQueueResolver.php
+++ b/src/DependencyResolver/ImportQueueResolver.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\content_sync\DependencyResolver;
 
+use Drupal\content_sync\ContentSyncManagerInterface;
 use Drupal\Core\Serialization\Yaml;
 
 /**

--- a/src/DependencyResolver/ImportQueueResolver.php
+++ b/src/DependencyResolver/ImportQueueResolver.php
@@ -80,7 +80,7 @@ class ImportQueueResolver implements ContentSyncResolverInterface {
     }
     else {
       list($entity_type_id, $bundle, $uuid) = explode('.', $identifier);
-      $file_path = content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/entities/".$entity_type_id."/".$bundle."/".$identifier.".yml";
+      $file_path = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY)."/entities/".$entity_type_id."/".$bundle."/".$identifier.".yml";
       $raw_entity = file_get_contents($file_path);
 
       // Problems to open the .yml file.

--- a/src/Form/ContentExportTrait.php
+++ b/src/Form/ContentExportTrait.php
@@ -26,10 +26,13 @@ trait ContentExportTrait {
    * export_type:
    * Tar -> YML to Tar file
    * Snapshot -> YML to content_sync table.
-   * Directory -> YML to content_sync_directory_entities.
+   * Directory -> YML to content_sync_directory_entities
+   *
+   * content_sync_directory:
+   * path for the content sync directory.
    *
    * content_sync_directory_entities:
-   * path for the content sync directory.
+   * path for the content sync entities directory.
    *
    * content_sync_directory_files:
    * path to store media/files.
@@ -40,10 +43,13 @@ trait ContentExportTrait {
    * @return array
    */
   public function generateExportBatch($entities, $serializer_context = []) {
-    $serializer_context['content_sync_directory_entities'] =  content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/entities";
+    if (!isset($serializer_context['content_sync_directory'])) {
+      $serializer_context['content_sync_directory'] = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
+    }
+    $serializer_context['content_sync_directory_entities'] = $serializer_context['content_sync_directory'] . "/entities";
     if (isset($serializer_context['include_files'])){
       if ($serializer_context['include_files'] == 'folder'){
-        $serializer_context['content_sync_directory_files'] =  content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/files";
+        $serializer_context['content_sync_directory_files'] = $serializer_context['content_sync_directory'] . "/files";
       }
       if ($serializer_context['include_files'] == 'base64'){
         $serializer_context['content_sync_file_base_64'] = TRUE;

--- a/src/Form/ContentImportForm.php
+++ b/src/Form/ContentImportForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\content_sync\Form;
 
+use Drupal\content_sync\ContentSyncManagerInterface;
 use Drupal\Core\Archiver\ArchiveTar;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -21,7 +22,7 @@ class ContentImportForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $directory = content_sync_get_content_directory('sync');
+    $directory = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
     $directory_is_writable = is_writable($directory);
     if (!$directory_is_writable) {
       $this->logger('content_sync')->error('The directory %directory is not writable.', ['%directory' => $directory, 'link' => 'Import Archive']);
@@ -62,7 +63,7 @@ class ContentImportForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     if ($path = $form_state->getValue('import_tarball')) {
-      $directory = content_sync_get_content_directory('sync');
+      $directory = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
       emptyDirectory($directory);
       try {
         $archiver = new ArchiveTar($path, 'gz');

--- a/src/Form/ContentImportTrait.php
+++ b/src/Form/ContentImportTrait.php
@@ -32,8 +32,8 @@ trait ContentImportTrait {
     if (!isset($serializer_context['content_sync_directory'])) {
       $serializer_context['content_sync_directory'] = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
     }
-    $serializer_context['content_sync_directory_entities'] =  content_sync_get_content_directory($serializer_context['content_sync_directory']) . "/entities";
-    $serializer_context['content_sync_directory_files'] =  content_sync_get_content_directory($serializer_context['content_sync_directory']) . "/files";
+    $serializer_context['content_sync_directory_entities'] =  $serializer_context['content_sync_directory'] . "/entities";
+    $serializer_context['content_sync_directory_files'] =  $serializer_context['content_sync_directory'] . "/files";
     $operations[] = [[$this, 'deleteContent'], [$content_to_delete, $serializer_context]];
     $operations[] = [[$this, 'syncContent'], [$content_to_sync, $serializer_context]];
 

--- a/src/Form/ContentImportTrait.php
+++ b/src/Form/ContentImportTrait.php
@@ -23,15 +23,17 @@ trait ContentImportTrait {
    * @param $content_to_delete
    *
    * @param $serializer_context
-   *
-   * content_sync_directory:
-   * path for the content sync directory.
+   *   content_sync_directory
+   *     The content sync directory from which to import.
    *
    * @return array
    */
   public function generateImportBatch($content_to_sync, $content_to_delete, $serializer_context = []) {
-    $serializer_context['content_sync_directory_entities'] =  content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/entities";
-    $serializer_context['content_sync_directory_files'] =  content_sync_get_content_directory(CONFIG_SYNC_DIRECTORY)."/files";
+    if (!isset($serializer_context['content_sync_directory'])) {
+      $serializer_context['content_sync_directory'] = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
+    }
+    $serializer_context['content_sync_directory_entities'] =  $serializer_context['content_sync_directory'] . "/entities";
+    $serializer_context['content_sync_directory_files'] =  $serializer_context['content_sync_directory'] . "/files";
     $operations[] = [[$this, 'deleteContent'], [$content_to_delete, $serializer_context]];
     $operations[] = [[$this, 'syncContent'], [$content_to_sync, $serializer_context]];
 

--- a/src/Form/ContentImportTrait.php
+++ b/src/Form/ContentImportTrait.php
@@ -32,8 +32,8 @@ trait ContentImportTrait {
     if (!isset($serializer_context['content_sync_directory'])) {
       $serializer_context['content_sync_directory'] = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
     }
-    $serializer_context['content_sync_directory_entities'] =  $serializer_context['content_sync_directory'] . "/entities";
-    $serializer_context['content_sync_directory_files'] =  $serializer_context['content_sync_directory'] . "/files";
+    $serializer_context['content_sync_directory_entities'] =  content_sync_get_content_directory($serializer_context['content_sync_directory']) . "/entities";
+    $serializer_context['content_sync_directory_files'] =  content_sync_get_content_directory($serializer_context['content_sync_directory']) . "/files";
     $operations[] = [[$this, 'deleteContent'], [$content_to_delete, $serializer_context]];
     $operations[] = [[$this, 'syncContent'], [$content_to_sync, $serializer_context]];
 
@@ -110,7 +110,7 @@ trait ContentImportTrait {
   /**
    * Processes the content import to be deleted or created batch and persists the importer.
    *
-   * @param $content_to_sync
+   * @param $content_to_delete
    * @param string $serializer_context
    * @param array $context
    *   The batch context.

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -45,16 +45,16 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
     $original_data = $data;
 
     // Get the entity type ID while letting context override the $class param.
-    $entity_type_id = !empty($context['entity_type']) ? $context['entity_type'] : $this->entityManager->getEntityTypeFromClass($class);
+    $entity_type_id = !empty($context['entity_type']) ? $context['entity_type'] : $this->entityTypeManager->getEntityTypeFromClass($class);
 
     $bundle = FALSE;
     /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type_definition */
     // Get the entity type definition.
-    $entity_type_definition = $this->entityManager->getDefinition($entity_type_id, FALSE);
+    $entity_type_definition = $this->entityTypeManager->getDefinition($entity_type_id, FALSE);
     if ($entity_type_definition->hasKey('bundle')) {
       $bundle_key = $entity_type_definition->getKey('bundle');
       // Get the base field definitions for this entity type.
-      $base_field_definitions = $this->entityManager->getBaseFieldDefinitions($entity_type_id);
+      $base_field_definitions = $this->entityTypeManager->getBaseFieldDefinitions($entity_type_id);
 
       // Get the ID key from the base field definition for the bundle key or
       // default to 'value'.
@@ -221,13 +221,13 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
    */
   protected function fixReferences(&$data, $entity_type_id, $bundle = FALSE) {
     if ($bundle) {
-      $field_definitions = $this->entityManager->getFieldDefinitions($entity_type_id, $bundle);
+      $field_definitions = $this->entityTypeManager->getFieldDefinitions($entity_type_id, $bundle);
     }
     else {
-      $bundles = array_keys($this->entityManager->getBundleInfo($entity_type_id));
+      $bundles = array_keys($this->entityTypeManager->getBundleInfo($entity_type_id));
       $field_definitions = [];
       foreach ($bundles as $bundle) {
-        $field_definitions_bundle = $this->entityManager->getFieldDefinitions($entity_type_id, $bundle);
+        $field_definitions_bundle = $this->entityTypeManager->getFieldDefinitions($entity_type_id, $bundle);
         if (is_array($field_definitions_bundle)) {
           $field_definitions += $field_definitions_bundle;
         }
@@ -243,7 +243,7 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
           ->getMainPropertyName();
         foreach ($data[$field_name] as $i => &$item) {
           if (!empty($item['target_uuid'])) {
-            $reference = $this->entityManager->loadEntityByUuid($item['target_type'], $item['target_uuid']);
+            $reference = $this->entityTypeManager->loadEntityByUuid($item['target_type'], $item['target_uuid']);
             if ($reference) {
               $item[$key] = $reference->id();
               if (is_a($reference, RevisionableInterface::class, TRUE)) {
@@ -251,7 +251,7 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
               }
             }
             else {
-              $reflection = new \ReflectionClass($this->entityManager->getStorage($item['target_type'])->getEntityType()->getClass());
+              $reflection = new \ReflectionClass($this->entityTypeManager->getStorage($item['target_type'])->getEntityType()->getClass());
               if ($reflection->implementsInterface(ContentEntityInterface::class)) {
                 unset($data[$field_name][$i]);
               }
@@ -269,13 +269,13 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
    */
   protected function cleanupData(&$data, $entity_type_id, $bundle = FALSE) {
     if ($bundle) {
-      $field_definitions = $this->entityManager->getFieldDefinitions($entity_type_id, $bundle);
+      $field_definitions = $this->entityTypeManager->getFieldDefinitions($entity_type_id, $bundle);
     }
     else {
-      $bundles = array_keys($this->entityManager->getBundleInfo($entity_type_id));
+      $bundles = array_keys($this->entityTypeManager->getBundleInfo($entity_type_id));
       $field_definitions = [];
       foreach ($bundles as $bundle) {
-        $field_definitions_bundle = $this->entityManager->getFieldDefinitions($entity_type_id, $bundle);
+        $field_definitions_bundle = $this->entityTypeManager->getFieldDefinitions($entity_type_id, $bundle);
         if (is_array($field_definitions_bundle)) {
           $field_definitions += $field_definitions_bundle;
         }

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -4,6 +4,11 @@ namespace Drupal\content_sync\Normalizer;
 
 use Drupal\content_sync\Plugin\SyncNormalizerDecoratorManager;
 use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
+use Drupal\Core\Entity\EntityRepository;
 use Drupal\Core\File\FileSystemInterface;
 
 /**
@@ -28,14 +33,36 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
   /**
    * FileEntityNormalizer constructor.
    *
-   * @param EntityManagerInterface $entity_manager
+   * @param EntityTypeManagerInterface $entity_manager
    *
    * @param SyncNormalizerDecoratorManager $decorator_manager
    *
    * @param FileSystemInterface $file_system
+   *
+   * @param EntityTypeRepositoryInterface $entity_type_repository
+   *
+   * @param EntityTypeBundleInfo $entity_type_bundle_info
+   *
+   * @param EntityFieldManager $entity_field_manager
+   *
+   * @param EntityRepository $entity_repository
    */
-  public function __construct(EntityManagerInterface $entity_manager, SyncNormalizerDecoratorManager $decorator_manager, FileSystemInterface $file_system) {
-    parent::__construct($entity_manager, $decorator_manager);
+  public function __construct(
+    EntityTypeManagerInterface $entity_manager,
+    SyncNormalizerDecoratorManager $decorator_manager,
+    FileSystemInterface $file_system,
+    EntityTypeRepositoryInterface $entity_type_repository,
+    EntityTypeBundleInfo $entity_type_bundle_info,
+    EntityFieldManager $entity_field_manager,
+    EntityRepository $entity_repository) {
+    parent::__construct(
+      $entity_manager,
+      $decorator_manager,
+      $entity_type_repository,
+      $entity_type_bundle_info,
+      $entity_field_manager,
+      $entity_repository
+    );
     $this->fileSystem = $file_system;
   }
 


### PR DESCRIPTION
Changes:

- `drush cse [label] [options]` works now
- `drush csi [label] [options]` works now
- all associated entityManager stuff has been refactored to work with latest Drupal core serialization module ([this commit introduced the refactor in serialization](https://git.drupalcode.org/project/drupal/commit/7dcda1f625d4581b75172d3af055010c6e99d32c))

Notes:
cse and csi were already started, so I left them as close to original as possible, and I based my changes on [cim](https://github.com/drush-ops/drush/blob/9.7.1/src/Drupal/Commands/config/ConfigImportCommands.php#L162) and [cem](https://github.com/drush-ops/drush/blob/9.7.1/src/Drupal/Commands/config/ConfigExportCommands.php#L85), and the refactoring was guided by repeated testing of the commands and following the trail of errors.