### PR TITLE
D10-35 / D10-28: Avoid some deprecation notices.

### DIFF
--- a/src/Form/ContentExportTrait.php
+++ b/src/Form/ContentExportTrait.php
@@ -76,7 +76,7 @@ trait ContentExportTrait {
    *
    * @return array
    */
-  public function generateExportBatch($entities = [], $serializer_context = []) {
+  public function generateExportBatch(array $entities = [], array $serializer_context = []) {
     if (!isset($serializer_context['content_sync_directory'])) {
       $serializer_context['content_sync_directory'] = content_sync_get_content_directory(ContentSyncManagerInterface::DEFAULT_DIRECTORY);
     }
@@ -129,7 +129,7 @@ trait ContentExportTrait {
    *   - entity_uuid: The UUID of the identified entity.
    */
   protected static function exportSplitName($name) {
-    list($entity_type, , $entity_uuid) = explode('.', $name);
+    [$entity_type, , $entity_uuid] = explode('.', $name);
     return compact('entity_type', 'entity_uuid');
   }
 
@@ -138,10 +138,10 @@ trait ContentExportTrait {
    *
    * @param array $serializer_context
    *   The serializer context.
-   * @param array|DrushBatchContext $context
+   * @param \DrushBatchContext|array $context
    *   The batch context.
    */
-  public function processContentExportFiles($serializer_context = [], &$context) {
+  public function processContentExportFiles(array $serializer_context = [], &$context = []) {
     //Initialize Batch
     if (!isset($context['sandbox']['progress'])) {
       $context['sandbox']['progress'] = 0;
@@ -282,12 +282,12 @@ trait ContentExportTrait {
    * Generate UUID YAML file
    * To use for site UUID validation.
    *
-   * @param $data
+   * @param array $serializer_context
    *   The batch content to persist.
-   * @param array $context
+   * @param \DrushBatchContext|array $context
    *   The batch context.
    */
-  public function generateSiteUUIDFile($serializer_context, &$context) {
+  public function generateSiteUUIDFile(array $serializer_context, &$context) {
     //Include Site UUID to YML file
     $site_config = \Drupal::config('system.site');
     $site_uuid_source = $site_config->get('uuid');

--- a/src/Form/ContentImportTrait.php
+++ b/src/Form/ContentImportTrait.php
@@ -87,11 +87,11 @@ trait ContentImportTrait {
   /**
    * Processes the content import to be updated or created batch and persists the importer.
    *
-   * @param string $serializer_context
-   * @param array $context
+   * @param array $serializer_context
+   * @param \DrushBatchContext|array $context
    *   The batch context.
    */
-  public function syncContent($serializer_context = [], &$context) {
+  public function syncContent(array $serializer_context = [], &$context = []) {
     if (empty($context['sandbox'])) {
       $context['sandbox']['progress'] = 0;
       $context['sandbox']['directory'] = $serializer_context['content_sync_directory_entities'];
@@ -148,11 +148,11 @@ trait ContentImportTrait {
   /**
    * Processes the content import to be deleted or created batch and persists the importer.
    *
-   * @param string $serializer_context
-   * @param array $context
+   * @param array $serializer_context
+   * @param array|\DrushBatchContext $context
    *   The batch context.
    */
-  public function deleteContent($serializer_context = [], &$context) {
+  public function deleteContent(array $serializer_context = [], &$context = []) {
     if (empty($context['sandbox'])) {
       $context['sandbox']['progress'] = 0;
       $context['sandbox']['directory'] = $serializer_context['content_sync_directory_entities'];
@@ -163,7 +163,7 @@ trait ContentImportTrait {
       $error = TRUE;
       $item = $queue_item->data;
       $ids = explode('.', $item);
-      list($entity_type_id, $bundle, $uuid) = $ids;
+      [$entity_type_id, $bundle, $uuid] = $ids;
 
       $entity = $this->contentSyncManager->getEntityTypeManager()->getStorage($entity_type_id)
                                          ->loadByProperties(['uuid' => $uuid]);


### PR DESCRIPTION
Having the parameter without a default specified _after_ a parameter with a default was causing some notices, which propagated into errors in different contexts.