### PR TITLE
[SUP-6256] Only use content sync normalizers for content sync processes

### DIFF
--- a/src/Exporter/ContentExporter.php
+++ b/src/Exporter/ContentExporter.php
@@ -27,12 +27,11 @@ class ContentExporter implements ContentExporterInterface {
    */
   public function exportEntity(ContentEntityInterface $entity, array $context = []) {
     $context = $this->context + $context;
-    // Allows to know to normalizers that this is a content sync generated entity.
+    // Allows normalizers to know that this is a content sync generated entity.
     $context += [
       'content_sync' => TRUE,
     ];
-    // Allows normalizers to know that this is a content sync generated entity.
-    $entity->is_content_sync = TRUE;
+
     $normalized_entity = $this->serializer->serialize($entity, $this->format, $context);
 //    $return = [
 //      'entity_type_id' => $entity->getEntityTypeId(),

--- a/src/Exporter/ContentExporter.php
+++ b/src/Exporter/ContentExporter.php
@@ -31,7 +31,8 @@ class ContentExporter implements ContentExporterInterface {
     $context += [
       'content_sync' => TRUE,
     ];
-
+    // Allows normalizers to know that this is a content sync generated entity.
+    $entity->is_content_sync = TRUE;
     $normalized_entity = $this->serializer->serialize($entity, $this->format, $context);
 //    $return = [
 //      'entity_type_id' => $entity->getEntityTypeId(),

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -303,4 +303,19 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
     }
   }
 
+
+  /**
+   * @inheritdoc
+   */
+  public function supportsNormalization($data, $format = NULL, array $context = []): bool {
+    return parent::supportsNormalization($data, $format, $context) && !empty($data->is_content_sync);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function supportsDenormalization($data, $type, $format = NULL, array $context = []): bool {
+    return parent::supportsDenormalization($data, $type, $format, $context);
+  }
+
 }

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -308,7 +308,7 @@ class ContentEntityNormalizer extends BaseContentEntityNormalizer {
    * @inheritdoc
    */
   public function supportsNormalization($data, $format = NULL, array $context = []): bool {
-    return parent::supportsNormalization($data, $format, $context) && !empty($data->is_content_sync);
+    return parent::supportsNormalization($data, $format, $context) && ($context['content_sync'] ?? FALSE);
   }
 
   /**


### PR DESCRIPTION
Without this flagging in place, the content sync normalizer was firing for everything and cleaning entity IDs out of places like rest endpoints used to get entities as json.

This should be a patch release.