### PR TITLE
D11-11 / D11-5 : Bump core version, fix serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "suggest": {},
     "conflict": {
-        "drupal/core": "<10"
+        "drupal/core": "<10.1"
     },
     "replace": {
         "drupal/content_sync": "^2"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0+",
     "suggest": {},
-    "require": {
-        "drupal/core": "^10"
+    "conflict": {
+        "drupal/core": "<10"
     },
     "replace": {
         "drupal/content_sync": "^2"

--- a/content_sync.info.yml
+++ b/content_sync.info.yml
@@ -2,7 +2,7 @@ name: 'Content Sync'
 type: module
 description: 'Allows to import/export content using YAML files'
 package: Custom
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 configure: content.sync
 dependencies:
   - drupal:serialization (>=8.6.10)

--- a/content_sync.info.yml
+++ b/content_sync.info.yml
@@ -2,7 +2,7 @@ name: 'Content Sync'
 type: module
 description: 'Allows to import/export content using YAML files'
 package: Custom
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.1 || ^11
 configure: content.sync
 dependencies:
   - drupal:serialization (>=8.6.10)

--- a/src/Encoder/YamlEncoder.php
+++ b/src/Encoder/YamlEncoder.php
@@ -31,11 +31,11 @@ class YamlEncoder implements EncoderInterface, DecoderInterface{
     $this->yaml = $yaml;
   }
 
-  public function decode($data, $format, array $context = array()) {
+  public function decode($data, $format, array $context = array()) : mixed {
     return $this->yaml->decode($data);
   }
 
-  public function supportsDecoding($format) {
+  public function supportsDecoding($format) : bool {
     return $format == $this->format;
   }
 

--- a/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -46,7 +46,7 @@ class EntityReferenceFieldItemNormalizer extends FieldItemNormalizer {
     $values = parent::normalize($field_item, $format, $context);
 
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
-    if ($entity = $field_item->get('entity')->getValue()) {
+    if ($entity = ($field_item->getValue()['entity'] ?? NULL)) {
       $values['target_type'] = $entity->getEntityTypeId();
       // Add the target entity UUID to the normalized output values.
       $values['target_uuid'] = $entity->uuid();

--- a/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -16,13 +16,6 @@ use Drupal\Core\Entity\RevisionableInterface;
 class EntityReferenceFieldItemNormalizer extends FieldItemNormalizer {
 
   /**
-   * The interface or class that this Normalizer supports.
-   *
-   * @var string
-   */
-  protected $supportedInterfaceOrClass = EntityReferenceItem::class;
-
-  /**
    * The entity repository.
    *
    * @var \Drupal\Core\Entity\EntityRepositoryInterface
@@ -91,6 +84,15 @@ class EntityReferenceFieldItemNormalizer extends FieldItemNormalizer {
       }
     }
     return parent::constructValue($data, $context);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSupportedTypes(?string $format) : array {
+    return [
+      EntityReferenceItem::class => TRUE,
+    ];
   }
 
 }

--- a/src/Normalizer/FileEntityNormalizer.php
+++ b/src/Normalizer/FileEntityNormalizer.php
@@ -11,18 +11,12 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\FileInterface;
 
 /**
  * Adds the file URI to embedded file entities.
  */
 class FileEntityNormalizer extends ContentEntityNormalizer {
-
-  /**
-   * The interface or class that this Normalizer supports.
-   *
-   * @var string
-   */
-  protected $supportedInterfaceOrClass = 'Drupal\file\FileInterface';
 
   /**
    * File system service.
@@ -153,6 +147,15 @@ class FileEntityNormalizer extends ContentEntityNormalizer {
     }
 
     return $data;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSupportedTypes(?string $format) : array {
+    return [
+      FileInterface::class => TRUE,
+    ];
   }
 
 }

--- a/src/Normalizer/ImageItemNormalizer.php
+++ b/src/Normalizer/ImageItemNormalizer.php
@@ -2,18 +2,10 @@
 
 namespace Drupal\content_sync\Normalizer;
 
-
 use Drupal\image\Plugin\Field\FieldType\ImageItem;
 use Drupal\serialization\Normalizer\EntityReferenceFieldItemNormalizer;
 
 class ImageItemNormalizer extends EntityReferenceFieldItemNormalizer {
-
-  /**
-   * The interface or class that this Normalizer supports.
-   *
-   * @var string
-   */
-  protected $supportedInterfaceOrClass = ImageItem::class;
 
   /**
    * {@inheritdoc}
@@ -26,6 +18,15 @@ class ImageItemNormalizer extends EntityReferenceFieldItemNormalizer {
       }
     }
     return $denormalized_data;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSupportedTypes(?string $format) : array {
+    return [
+      ImageItem::class => TRUE,
+    ];
   }
 
 }

--- a/src/Normalizer/TextItemNormalizer.php
+++ b/src/Normalizer/TextItemNormalizer.php
@@ -19,7 +19,7 @@ class TextItemNormalizer extends NormalizerBase {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []) {
+  public function normalize($object, $format = NULL, array $context = []) : float|int|bool|\ArrayObject|array|string|null {
     $attributes = [];
     foreach ($object->getProperties(TRUE) as $name => $field) {
       $value = $this->serializer->normalize($field, $format, $context);

--- a/src/Normalizer/TextItemNormalizer.php
+++ b/src/Normalizer/TextItemNormalizer.php
@@ -3,18 +3,12 @@
 namespace Drupal\content_sync\Normalizer;
 
 use Drupal\serialization\Normalizer\NormalizerBase;
+use Drupal\text\Plugin\Field\FieldType\TextItemBase;
 
 /**
  * Converts TextItem fields to an array including computed values.
  */
 class TextItemNormalizer extends NormalizerBase {
-
-  /**
-   * The interface or class that this Normalizer supports.
-   *
-   * @var string
-   */
-  protected $supportedInterfaceOrClass = 'Drupal\text\Plugin\Field\FieldType\TextItemBase';
 
   /**
    * {@inheritdoc}
@@ -29,6 +23,16 @@ class TextItemNormalizer extends NormalizerBase {
       $attributes[$name] = $value;
     }
     return $attributes;
+  }
+
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSupportedTypes(?string $format) : array {
+    return [
+      TextItemBase::class => TRUE,
+    ];
   }
 
 }

--- a/src/Normalizer/UserEntityNormalizer.php
+++ b/src/Normalizer/UserEntityNormalizer.php
@@ -2,18 +2,12 @@
 
 namespace Drupal\content_sync\Normalizer;
 
+use Drupal\user\UserInterface;
+
 /**
  * User entity normalizer class.
  */
 class UserEntityNormalizer extends ContentEntityNormalizer {
-
-
-  /**
-   * The interface or class that this Normalizer supports.
-   *
-   * @var string
-   */
-  protected $supportedInterfaceOrClass = 'Drupal\user\UserInterface';
 
   /**
    * {@inheritdoc}
@@ -67,4 +61,14 @@ class UserEntityNormalizer extends ContentEntityNormalizer {
     }
     return $metadata;
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSupportedTypes(?string $format) : array {
+    return [
+      UserInterface::class => TRUE,
+    ];
+  }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated module to require Drupal 10.1 or later and added support for Drupal 11.

* **Refactor**
  * Enhanced type safety and improved internal serialization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->