### PR TITLE
SEC-2528: Environment variable suppressing snapshot generation on installation.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,8 @@ INSTALLATION
 Extract module at drupal/modules/contrib directory and enable it from browser
 by going in this path /admin/modules.
 
+The `CONTENT_SYNC__SUPPRESS_SNAPSHOT_ON_INSTALL` environment variable might be set dto soemthing truthy in order to skip the build of the snapshot during module installation, with the expectation that the snapshot will be built by other means, such as the `drush content-sync:snapshot` command ( https://github.com/discoverygarden/content_sync/blob/7816728adc70b3c85642bd254b9096a44a1d0308/src/Drush/Commands/ContentSyncCommands.php#L519-L528 ).
+
 
 CONFIGURATION
 -------------

--- a/README.txt
+++ b/README.txt
@@ -21,7 +21,7 @@ INSTALLATION
 Extract module at drupal/modules/contrib directory and enable it from browser
 by going in this path /admin/modules.
 
-The `CONTENT_SYNC__SUPPRESS_SNAPSHOT_ON_INSTALL` environment variable might be set dto soemthing truthy in order to skip the build of the snapshot during module installation, with the expectation that the snapshot will be built by other means, such as the `drush content-sync:snapshot` command ( https://github.com/discoverygarden/content_sync/blob/7816728adc70b3c85642bd254b9096a44a1d0308/src/Drush/Commands/ContentSyncCommands.php#L519-L528 ).
+The `CONTENT_SYNC__SUPPRESS_SNAPSHOT_ON_INSTALL` environment variable might be set to something truthy in order to skip the build of the snapshot during module installation, with the expectation that the snapshot will be built by other means such as the `drush content-sync:snapshot` command ( https://github.com/discoverygarden/content_sync/blob/7816728adc70b3c85642bd254b9096a44a1d0308/src/Drush/Commands/ContentSyncCommands.php#L519-L528 ).
 
 
 CONFIGURATION

--- a/content_sync.install
+++ b/content_sync.install
@@ -7,10 +7,12 @@
 /**
  * Implements hook_install().
  */
-function content_sync_install(){
-  //Create the content snapshot.
-  $cs_snapshoot = Drupal::service('content_sync.snaphoshot');
-  $cs_snapshoot->snapshot();
+function content_sync_install() {
+  if (!filter_var(getenv('CONTENT_SYNC__SUPPRESS_SNAPSHOT_ON_INSTALL'), FILTER_VALIDATE_BOOLEAN)) { 
+    // Create the content snapshot.
+    $cs_snapshoot = Drupal::service('content_sync.snaphoshot');
+    $cs_snapshoot->snapshot();
+  }
 }
 
 /**


### PR DESCRIPTION
Snapshots might be rather intensive to build, and `hook_install()` can't kick off batches, so: Let's introduce an environment variable to allow the snapshot generation during module install to be suppressed, with the expectation of separate process being used to populate the snapshot, such as a `drush content-sync:snapshot` (which executes batch-wise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot creation during module installation can be suppressed via an environment configuration; snapshots can be created manually afterward.

* **Documentation**
  * Installation guide updated to explain how to suppress automatic snapshot creation and how to create snapshots later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->